### PR TITLE
[#24701] YSQL: fix UPDATE on subset of foreign constraint keys

### DIFF
--- a/src/postgres/src/include/pg_yb_utils.h
+++ b/src/postgres/src/include/pg_yb_utils.h
@@ -1253,4 +1253,6 @@ SortByDir YbGetIndexKeySortOrdering(Relation indexRel);
 
 bool YbUseUnsafeTruncate(Relation rel);
 
+bool YbIsAttrBmsMember(Relation rel, AttrNumber attnum, Bitmapset * bms);
+
 #endif /* PG_YB_UTILS_H */

--- a/src/postgres/src/test/regress/expected/yb_foreign_key.out
+++ b/src/postgres/src/test/regress/expected/yb_foreign_key.out
@@ -673,3 +673,20 @@ ERROR:  insert or update on table "child_2" violates foreign key constraint "chi
 DETAIL:  Key (v)=(1010002) is not present in table "parent".
 UPDATE child_1 SET v = v * 2 WHERE k < 5001;
 UPDATE child_2 SET v = (v - 1000000) * 2 + 1000000 WHERE k < 5001;
+-- test updating a subset of foreign constraint keys.
+CREATE TABLE pk(id INT, name INT, PRIMARY KEY (id, name));
+CREATE TABLE fk(id INT, name INT, FOREIGN KEY(id, name) REFERENCES pk(id, name));
+INSERT INTO pk VALUES (1, 500);
+INSERT INTO pk VALUES (1, 505);
+INSERT INTO fk VALUES (1, 500);
+UPDATE fk set name = name + 1; -- should fail
+ERROR:  insert or update on table "fk" violates foreign key constraint "fk_id_name_fkey"
+DETAIL:  Key (id, name)=(1, 501) is not present in table "pk".
+UPDATE fk set name = name + 5; -- should pass
+SELECT * from fk;
+ id | name 
+----+------
+  1 |  505
+(1 row)
+
+DROP TABLE pk, fk;

--- a/src/postgres/src/test/regress/sql/yb_foreign_key.sql
+++ b/src/postgres/src/test/regress/sql/yb_foreign_key.sql
@@ -419,3 +419,14 @@ UPDATE child_2 SET v = (v - 1000000) * 2 + 1000000 WHERE k <= 5001; -- should fa
 
 UPDATE child_1 SET v = v * 2 WHERE k < 5001;
 UPDATE child_2 SET v = (v - 1000000) * 2 + 1000000 WHERE k < 5001;
+
+-- test updating a subset of foreign constraint keys.
+CREATE TABLE pk(id INT, name INT, PRIMARY KEY (id, name));
+CREATE TABLE fk(id INT, name INT, FOREIGN KEY(id, name) REFERENCES pk(id, name));
+INSERT INTO pk VALUES (1, 500);
+INSERT INTO pk VALUES (1, 505);
+INSERT INTO fk VALUES (1, 500);
+UPDATE fk set name = name + 1; -- should fail
+UPDATE fk set name = name + 5; -- should pass
+SELECT * from fk;
+DROP TABLE pk, fk;


### PR DESCRIPTION
Summary: TBD

Test Plan: ./yb_build.sh --java-test org.yb.pgsql.TestPgRegressForeignKey

Subscribers: yql

Differential Revision: https://phorge.dev.yugabyte.com/D39602